### PR TITLE
fix: Major Fix on 2024

### DIFF
--- a/ZZCarouselSwift.podspec
+++ b/ZZCarouselSwift.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
 
   s.name         = "ZZCarouselSwift"
   s.version      = "1.2.3"
-  s.summary      = "1.2.1 Major update"
+  s.summary      = "1.2.3 Major update"
 
   # This description is used to generate tags and improve search results.
   #   * Think: What does it do? Why did you write it? What is the focus?

--- a/ZZCarouselSwift.podspec
+++ b/ZZCarouselSwift.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "ZZCarouselSwift"
-  s.version      = "1.2.1"
+  s.version      = "1.2.3"
   s.summary      = "1.2.1 Major update"
 
   # This description is used to generate tags and improve search results.

--- a/ZZCarouselSwift.podspec
+++ b/ZZCarouselSwift.podspec
@@ -133,4 +133,10 @@ Pod::Spec.new do |s|
   # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
   # s.dependency "JSONKit", "~> 1.4"
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '4.2' }
+  
+  # ――― Resources Bundles ―――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  
+  s.ios.resource_bundles = {'ZZCarouselSwift' => ['ZZCarouselSwift/PrivacyInfo.xcprivacy']}
+
+  
 end

--- a/ZZCarouselSwift/PrivacyInfo.xcprivacy
+++ b/ZZCarouselSwift/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/ZZCarouselSwift/ZZCarouselView.swift
+++ b/ZZCarouselSwift/ZZCarouselView.swift
@@ -227,23 +227,31 @@ open class ZZCarouselView: UIView {
     }
     
     private func settingPageControlAlignment() {
-//        let pointSize: CGSize = pageControl.size(forNumberOfPages: _carouselData.count)
-//        var page_x: CGFloat = 0.0
+        var page_x: CGFloat = 0.0
         var constraints = self.constraints
         
         if let index = constraints.firstIndex(where: {$0.identifier == "pageControlConstraints"}) {
+            NSLayoutConstraint.deactivate(constraints)
+            
             if pageControlAlignment == ZZCarouselPageAlignment.left {
-                constraints[index] = NSLayoutConstraint(item: pageControl, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)
+                page_x = 5
             } else if pageControlAlignment == ZZCarouselPageAlignment.right {
-                constraints[index] = NSLayoutConstraint(item: pageControl, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)
+                page_x = -(5)
+            }
+            
+            if pageControlAlignment == ZZCarouselPageAlignment.left {
+                constraints[index] = NSLayoutConstraint(item: pageControl, attribute: .leading, relatedBy: .equal, toItem: self, attribute: .leading, multiplier: 1, constant: page_x)
+            } else if pageControlAlignment == ZZCarouselPageAlignment.right {
+                constraints[index] = NSLayoutConstraint(item: pageControl, attribute: .trailing, relatedBy: .equal, toItem: self, attribute: .trailing, multiplier: 1, constant: page_x)
             } else if pageControlAlignment == ZZCarouselPageAlignment.center {
                 constraints[index] = NSLayoutConstraint(item: pageControl, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)
             } else {
-                
+                constraints[index] = NSLayoutConstraint(item: pageControl, attribute: .centerX, relatedBy: .equal, toItem: self, attribute: .centerX, multiplier: 1, constant: 0)
             }
             constraints[index].identifier = "pageControlConstraints"
             NSLayoutConstraint.activate(constraints)
-//            self.layoutIfNeeded()
+            pageControl.layoutIfNeeded()
+            self.layoutIfNeeded()
         }
         
     }

--- a/ZZCarouselSwift/ZZCarouselView.swift
+++ b/ZZCarouselSwift/ZZCarouselView.swift
@@ -9,8 +9,10 @@
 import UIKit
 
 public protocol ZZCarouselDelegate:class {
-    func carouselForItemCell(carouselView: ZZCarouselView, cell: UICollectionViewCell, indexItem: AnyObject) -> Void
-    func carouselDidSelectItemAtIndex(carouselView: ZZCarouselView, index: Int) -> Void
+    func carouselForItemCell(carouselView: ZZCarouselView, cell: UICollectionViewCell, indexItem: AnyObject)
+    func carouselDidSelectItemAtIndex(carouselView: ZZCarouselView, index: Int)
+    func totalItemPagger(total: Int)
+    func updatePaggerPosition(index: Int)
 }
 
 public enum ZZCarouselPageAlignment{
@@ -265,9 +267,11 @@ open class ZZCarouselView: UIView {
                 
                 if carouselData.count == 1 {
                     self?.pageControl.isHidden = true
+                    self?.delegate?.totalItemPagger(total: 1)
                     self?.invalidateTimer()
                 } else {
                     self?.pageControl.numberOfPages = carouselData.count
+                    self?.delegate?.totalItemPagger(total: carouselData.count)
                     self?.settingPageControlAlignment()
                     self?.defaultContentOffset()
                     self?.createTimer()
@@ -275,6 +279,7 @@ open class ZZCarouselView: UIView {
                 
                 if let curentPage = self?.fetchCurrentPage() {
                     self?.pageControl.currentPage = curentPage
+                    self?.delegate?.updatePaggerPosition(index: curentPage)
                 }
                 
                 if !(self?.isAutoScroll ?? false) {
@@ -454,7 +459,9 @@ extension ZZCarouselView: UICollectionViewDataSource, UICollectionViewDelegate, 
     }
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        self.pageControl.currentPage = fetchCurrentPage()
+        let index = fetchCurrentPage()
+        self.pageControl.currentPage = index
+        self.delegate?.updatePaggerPosition(index: index)
         if scrollDirection == ZZCarouselScrollDirection.left || scrollDirection == ZZCarouselScrollDirection.right {
             self.carouselHorizontalDidScroll(scrollView: scrollView)
         } else if scrollDirection == ZZCarouselScrollDirection.top || scrollDirection == ZZCarouselScrollDirection.bottom {

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo.xcodeproj/project.pbxproj
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 /* Begin PBXFileReference section */
 		15415EC4440A2478ACFA0A90 /* Pods-ZZCarouselSwiftDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZZCarouselSwiftDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-ZZCarouselSwiftDemo/Pods-ZZCarouselSwiftDemo.release.xcconfig"; sourceTree = "<group>"; };
 		4C4DACECC392A71845A690FC /* Pods_ZZCarouselSwiftDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ZZCarouselSwiftDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		72AA1CFE2B6234FA00CF12AA /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A431B54E1FC2BC1F004DD20D /* ZZCarouselView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZZCarouselView.swift; sourceTree = "<group>"; };
 		A45242A31FCD150E000A75EA /* tb_info_image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = tb_info_image.png; sourceTree = "<group>"; };
 		A45242A41FCD150E000A75EA /* jd_info_image.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = jd_info_image.png; sourceTree = "<group>"; };
@@ -130,6 +131,7 @@
 			isa = PBXGroup;
 			children = (
 				A431B54E1FC2BC1F004DD20D /* ZZCarouselView.swift */,
+				72AA1CFE2B6234FA00CF12AA /* PrivacyInfo.xcprivacy */,
 			);
 			name = ZZCarouselSwift;
 			path = ../../ZZCarouselSwift;

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example1ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example1ViewController.swift
@@ -10,7 +10,10 @@ import UIKit
 
 class Example1ViewController: UIViewController,ZZCarouselDelegate {
 
-    
+    private lazy var carousel: ZZCarouselView = {
+        let carousel = ZZCarouselView(width: self.view.frame.size.width, direction: .left)
+        return carousel
+    }()
 
 
     override func viewDidLoad() {
@@ -20,9 +23,9 @@ class Example1ViewController: UIViewController,ZZCarouselDelegate {
         // Do any additional setup after loading the view.
         
         let data = ["http://i1.douguo.net//upload/banner/0/6/a/06e051d7378040e13af03db6d93ffbfa.jpg", "http://i1.douguo.net//upload/banner/9/3/4/93f959b4e84ecc362c52276e96104b74.jpg", "http://i1.douguo.net//upload/banner/d/8/2/d89f438789ee1b381966c1361928cb32.jpg"]
-
+        setupView()
+        setupConstraints()
         
-        let carousel = ZZCarouselView.init(frame: CGRect(x: 0, y: 64, width: self.view.frame.size.width, height:self.view.frame.size.height / 3), direction: ZZCarouselScrollDirection.left)
         carousel.registerCarouselCell(cellClass: Example1Cell.self)
 
         carousel.setCurrentPageColor(color: UIColor.red)
@@ -35,6 +38,26 @@ class Example1ViewController: UIViewController,ZZCarouselDelegate {
         
         
         carousel.setCarouselData(carouselData: data as [AnyObject])
+    }
+    
+    private func setupView() {
+        self.view.addSubview(carousel)
+    }
+    
+    private func setupConstraints() {
+        let views: [String: Any] = ["carousel": carousel]
+        var constraints: [NSLayoutConstraint] = []
+        
+        carousel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let v_content = "V:|-[carousel]"
+        let h_carousel = "H:|-0-[carousel]-0-|"
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: v_content, options: .alignAllLeading, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_carousel, options: .alignAllTop, metrics: nil, views: views)
+        constraints += [NSLayoutConstraint(item: carousel, attribute: .height, relatedBy: .equal, toItem: self.view, attribute: .height, multiplier: 1/3, constant: 0)]
+        
+        NSLayoutConstraint.activate(constraints)
+        
     }
     
     func carouselForItemCell(carouselView: ZZCarouselView, cell: UICollectionViewCell, indexItem: AnyObject) {

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example1ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example1ViewController.swift
@@ -68,6 +68,14 @@ class Example1ViewController: UIViewController,ZZCarouselDelegate {
     func carouselDidSelectItemAtIndex(carouselView: ZZCarouselView, index: Int) {
         
     }
+    
+    func totalItemPagger(total: Int) {
+        
+    }
+    
+    func updatePaggerPosition(index: Int) {
+        
+    }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example2ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example2ViewController.swift
@@ -9,12 +9,24 @@
 import UIKit
 
 class Example2ViewController: UIViewController,ZZCarouselDelegate {
+    
+    private lazy var carousel: ZZCarouselView = {
+        let carousel = ZZCarouselView(width: self.view.frame.size.width, direction: .left)
+        return carousel
+    }()
+    
+    private lazy var carousel1: ZZCarouselView = {
+        let carousel = ZZCarouselView(width: self.view.frame.size.width, direction: .top)
+        return carousel
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         self.view.backgroundColor = UIColor.white
         // Do any additional setup after loading the view.
+        setupView()
+        setupConstraints()
         
         self.textCarouselDemo()
         
@@ -23,7 +35,6 @@ class Example2ViewController: UIViewController,ZZCarouselDelegate {
     func textCarouselDemo() -> Void {
         let data = ["昨天晴天转多云0℃-100℃", "今日晴天转多云0℃-100℃", "明天晴天转多云0℃-100℃", "后天晴天转多云0℃-100℃"]
         
-        let carousel = ZZCarouselView.init(frame: CGRect(x: 40, y: 84, width: self.view.frame.size.width - 80, height:40.0), direction: ZZCarouselScrollDirection.left)
         carousel.registerCarouselCell(cellClass: Example2Cell.classForCoder())
         carousel.setCurrentPageColor(color: UIColor.red)
         carousel.setDefaultPageColor(color: UIColor.yellow)
@@ -32,11 +43,8 @@ class Example2ViewController: UIViewController,ZZCarouselDelegate {
         carousel.setPageControlAlignment(alignment: ZZCarouselPageAlignment.right)
         carousel.setHiddenPageControl(hidden: true)
         carousel.setDisableScroll(disableScroll: false)
-        self.view.addSubview(carousel)
         carousel.setCarouselData(carouselData: data as [AnyObject])
         
-        
-        let carousel1 = ZZCarouselView.init(frame: CGRect(x: 40, y: 144, width: self.view.frame.size.width - 80, height:40.0), direction: ZZCarouselScrollDirection.top)
         carousel1.registerCarouselCell(cellClass: Example2Cell.classForCoder())
         carousel1.setDefaultPageColor(color: UIColor.yellow)
         carousel1.delegate = self
@@ -44,8 +52,33 @@ class Example2ViewController: UIViewController,ZZCarouselDelegate {
         carousel1.setPageControlAlignment(alignment: ZZCarouselPageAlignment.right)
         carousel1.setHiddenPageControl(hidden: true)
         carousel1.setDisableScroll(disableScroll: false)
-        self.view.addSubview(carousel1)
         carousel1.setCarouselData(carouselData: data as [AnyObject])
+    }
+    
+    private func setupView() {
+        self.view.addSubview(carousel)
+        self.view.addSubview(carousel1)
+    }
+    
+    private func setupConstraints() {
+        let views: [String: Any] = ["carousel": carousel,
+                                    "carousel1": carousel1]
+        var constraints: [NSLayoutConstraint] = []
+        
+        carousel.translatesAutoresizingMaskIntoConstraints = false
+        carousel1.translatesAutoresizingMaskIntoConstraints = false
+        
+        let v_content = "V:|-[carousel]-84-[carousel1]"
+        let h_carousel = "H:|-0-[carousel]-0-|"
+        let h_carousel1 = "H:|-0-[carousel1]-0-|"
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: v_content, options: .alignAllLeading, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_carousel, options: .alignAllTop, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_carousel1, options: .alignAllTop, metrics: nil, views: views)
+        constraints += [NSLayoutConstraint(item: carousel, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 40)]
+        constraints += [NSLayoutConstraint(item: carousel1, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 40)]
+        
+        NSLayoutConstraint.activate(constraints)
+        
     }
     
     func carouselForItemCell(carouselView: ZZCarouselView, cell: UICollectionViewCell, indexItem: AnyObject) {

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example2ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example2ViewController.swift
@@ -92,6 +92,14 @@ class Example2ViewController: UIViewController,ZZCarouselDelegate {
         
     }
     
+    func totalItemPagger(total: Int) {
+        
+    }
+    
+    func updatePaggerPosition(index: Int) {
+        
+    }
+    
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example3ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example3ViewController.swift
@@ -10,32 +10,57 @@ import UIKit
 
 class Example3ViewController: UIViewController,ZZCarouselDelegate {
     
-    
+    private lazy var carousel: ZZCarouselView = {
+        let carousel = ZZCarouselView(direction: .left)
+        return carousel
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
  
         self.view.backgroundColor = UIColor.white
         
+        setupView()
+        setupConstraints()
+        
         let data = [
-            ["title":"标题1","image":UIImage(named:"zz1.jpg") as Any],
-            ["title":"标题2","image":UIImage(named:"zz2.jpg") as Any],
-            ["title":"标题3","image":UIImage(named:"zz3.jpg") as Any],
-            ["title":"标题4","image":UIImage(named:"zz4.jpg") as Any],
-            ["title":"标题5","image":UIImage(named:"zz5.jpg") as Any],
+            ["title": "标题1","image": UIImage(named:"zz1.jpg") as Any],
+            ["title": "标题2","image": UIImage(named:"zz2.jpg") as Any],
+            ["title": "标题3","image": UIImage(named:"zz3.jpg") as Any],
+            ["title": "标题4","image": UIImage(named:"zz4.jpg") as Any],
+            ["title": "标题5","image": UIImage(named:"zz5.jpg") as Any],
         ]
         
-        let carousel = ZZCarouselView.init(frame: CGRect(x: 0, y: 64, width: self.view.frame.size.width, height:self.view.frame.size.height / 3), direction: ZZCarouselScrollDirection.left)
         carousel.registerCarouselCell(cellClass: Example3Cell.classForCoder())
         
         carousel.setCurrentPageColor(color: UIColor.red)
         carousel.setDefaultPageColor(color: UIColor.yellow)
         carousel.delegate = self
-        carousel.setAutoScrollTimeInterval(timeInterval: 2)
+//        carousel.setAutoScrollTimeInterval(timeInterval: 2)
+        carousel.setIsAutoScroll(isAutoScroll: false)
         carousel.setPageControlAlignment(alignment: ZZCarouselPageAlignment.right)
         carousel.setCarouselData(carouselData: data as [AnyObject])
-        carousel.tag = 1001;
+        carousel.tag = 1001
+    }
+    
+    private func setupView() {
         self.view.addSubview(carousel)
+    }
+    
+    private func setupConstraints() {
+        let views: [String: Any] = ["carousel": carousel]
+        var constraints: [NSLayoutConstraint] = []
+        
+        carousel.translatesAutoresizingMaskIntoConstraints = false
+        
+        let v_content = "V:|-[carousel]"
+        let h_carousel = "H:|-0-[carousel]-0-|"
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: v_content, options: .alignAllLeading, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_carousel, options: .alignAllTop, metrics: nil, views: views)
+        constraints += [NSLayoutConstraint(item: carousel, attribute: .height, relatedBy: .equal, toItem: self.view, attribute: .height, multiplier: 1/3, constant: 0)]
+        
+        NSLayoutConstraint.activate(constraints)
+        
     }
     
     func carouselForItemCell(carouselView: ZZCarouselView, cell: UICollectionViewCell, indexItem: AnyObject) {

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example3ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example3ViewController.swift
@@ -71,6 +71,14 @@ class Example3ViewController: UIViewController,ZZCarouselDelegate {
     func carouselDidSelectItemAtIndex(carouselView: ZZCarouselView, index: Int) {
         
     }
+    
+    func totalItemPagger(total: Int) {
+        
+    }
+    
+    func updatePaggerPosition(index: Int) {
+        
+    }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example4TaobaoCell.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example4TaobaoCell.swift
@@ -70,6 +70,6 @@ class Example4TaobaoCell: UICollectionViewCell {
     }
     
     required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: aDecoder)
     }
 }

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example4ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example4ViewController.swift
@@ -9,6 +9,25 @@
 import UIKit
 
 class Example4ViewController: UIViewController,ZZCarouselDelegate {
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .fill
+        stackView.backgroundColor = UIColor(white: 1, alpha: 0.001)
+        return stackView
+    }()
+    
+    private let imageView: UIImageView = {
+        let image = UIImageView()
+        return image
+    }()
+    
+    private lazy var carousel: ZZCarouselView = {
+        let carousel = ZZCarouselView(direction: .top)
+        return carousel
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -16,19 +35,17 @@ class Example4ViewController: UIViewController,ZZCarouselDelegate {
         self.view.backgroundColor = UIColor.white
 
         // Do any additional setup after loading the view.
-        
+        setupView()
+        setupConstraints()
         self.createTaobaoStyle()
     }
     
     func createTaobaoStyle() -> Void {
-        let imageView = UIImageView.init(frame: CGRect(x: 15, y: 84, width: 40, height: 40));
         imageView.image = UIImage.init(named: "tb_info_image")
-        self.view.addSubview(imageView);
         
         let data = [["title":"iPhoneX SEPlus美爆了，独家曝光","type":1,"subTitle":"X只是过渡 iphone11才是重头戏"],["title":"22万也能开特斯拉，上市当天订单","type":2,"subTitle":"众泰版奔驰来了，网友改装"],["title":"数据结构并非淘宝数据结构","type":3,"subTitle":"仿淘宝样式而已，后期需要自行处理"]
         ]
         
-        let carousel = ZZCarouselView.init(frame: CGRect(x: 60, y: 84, width: self.view.frame.size.width - 60, height:40.0), direction: ZZCarouselScrollDirection.top)
         carousel.registerCarouselCell(cellClass: Example4TaobaoCell.classForCoder())
         carousel.setCurrentPageColor(color: UIColor.red)
         carousel.setDefaultPageColor(color: UIColor.yellow)
@@ -37,8 +54,31 @@ class Example4ViewController: UIViewController,ZZCarouselDelegate {
         carousel.setPageControlAlignment(alignment: ZZCarouselPageAlignment.right)
         carousel.setHiddenPageControl(hidden: true)
         carousel.setDisableScroll(disableScroll: false)
-        self.view.addSubview(carousel)
         carousel.setCarouselData(carouselData: data as [AnyObject])
+        carousel.reloadData()
+    }
+    
+    private func setupView() {
+        self.view.addSubview(stackView)
+        stackView.addArrangedSubview(imageView)
+        stackView.addArrangedSubview(carousel)
+    }
+    
+    private func setupConstraints() {
+        let views: [String: Any] = ["stackView": stackView]
+        var constraints: [NSLayoutConstraint] = []
+        
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        let v_stackView = "V:|-[stackView]"
+        let h_stackView = "H:|-0-[stackView]-0-|"
+        
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: v_stackView, options: .alignAllLeading, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_stackView, options: .alignAllTop, metrics: nil, views: views)
+        constraints += [NSLayoutConstraint(item: stackView, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 40)]
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        constraints += [NSLayoutConstraint(item: imageView, attribute: .width, relatedBy: .equal, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 40)]
+        NSLayoutConstraint.activate(constraints)
         
     }
     

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example4ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/Example4ViewController.swift
@@ -92,6 +92,14 @@ class Example4ViewController: UIViewController,ZZCarouselDelegate {
     func carouselDidSelectItemAtIndex(carouselView: ZZCarouselView, index: Int) {
         
     }
+    
+    func totalItemPagger(total: Int) {
+        
+    }
+    
+    func updatePaggerPosition(index: Int) {
+        
+    }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/ExampleViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/ExampleViewController.swift
@@ -8,16 +8,27 @@
 
 import UIKit
 
-class ExampleViewController: UIViewController,ZZCarouselDelegate {
+class ExampleViewController: UIViewController, ZZCarouselDelegate {
+    
+    private lazy var carousel: ZZCarouselView = {
+        let carousel = ZZCarouselView(width: self.view.frame.size.width, direction: .top)
+        return carousel
+    }()
+    
+    private lazy var carousel1: ZZCarouselView = {
+        let carousel = ZZCarouselView(width: self.view.frame.size.width, direction: .left)
+        return carousel
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         self.view.backgroundColor = UIColor.white
+        setupView()
+        setupConstraints()
         
         let data = [UIImage(named:"zz1.jpg")!,UIImage(named:"zz2.jpg")!,UIImage(named:"zz3.jpg")!,UIImage(named:"zz4.jpg")!,UIImage(named:"zz5.jpg")!]
         
-        let carousel = ZZCarouselView.init(frame: CGRect(x: 0, y: 64, width: self.view.frame.size.width, height:self.view.frame.size.height / 3), direction: ZZCarouselScrollDirection.top)
         carousel.registerCarouselCell(cellClass: Example1Cell.classForCoder())
         
         carousel.setCurrentPageColor(color: UIColor.red)
@@ -30,11 +41,7 @@ class ExampleViewController: UIViewController,ZZCarouselDelegate {
         
         
         carousel.setCarouselData(carouselData: data)
-        carousel.tag = 1001;
-        self.view.addSubview(carousel)
-        
-        
-        let carousel1 = ZZCarouselView.init(frame: CGRect(x: 0, y: self.view.frame.size.height / 3 + 84.0, width: self.view.frame.size.width, height:self.view.frame.size.height / 3), direction: ZZCarouselScrollDirection.left)
+        carousel.tag = 1001
         
         carousel1.delegate = self
         carousel1.setAutoScrollTimeInterval(timeInterval: 2)
@@ -42,10 +49,34 @@ class ExampleViewController: UIViewController,ZZCarouselDelegate {
         
         carousel1.registerCarouselCell(cellClass: ExampleCell.classForCoder())
         carousel1.setPageControlAlignment(alignment: ZZCarouselPageAlignment.right)
-        //        carousel.setCurrentPageColor(color: UIColor.red)
-        //        carousel.setDefaultPageColor(color: UIColor.yellow)
         carousel1.tag = 1002
+        
+    }
+    
+    private func setupView() {
+        self.view.addSubview(carousel)
         self.view.addSubview(carousel1)
+    }
+    
+    private func setupConstraints() {
+        let views: [String: Any] = ["carousel": carousel, 
+                                    "carousel1": carousel1]
+        var constraints: [NSLayoutConstraint] = []
+        
+        carousel.translatesAutoresizingMaskIntoConstraints = false
+        carousel1.translatesAutoresizingMaskIntoConstraints = false
+        
+        let v_content = "V:|-[carousel]-84-[carousel1]"
+        let h_carousel = "H:|-0-[carousel]-0-|"
+        let h_carousel1 = "H:|-0-[carousel1]-0-|"
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: v_content, options: .alignAllLeading, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_carousel, options: .alignAllTop, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_carousel1, options: .alignAllTop, metrics: nil, views: views)
+        constraints += [NSLayoutConstraint(item: carousel, attribute: .height, relatedBy: .equal, toItem: self.view, attribute: .height, multiplier: 1/3, constant: 0)]
+        constraints += [NSLayoutConstraint(item: carousel1, attribute: .height, relatedBy: .equal, toItem: self.view, attribute: .height, multiplier: 1/3, constant: 0)]
+        
+        NSLayoutConstraint.activate(constraints)
+        
     }
     
     func carouselForItemCell(carouselView: ZZCarouselView, cell: UICollectionViewCell, indexItem: AnyObject) {

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/ExampleViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/ExampleViewController.swift
@@ -43,11 +43,11 @@ class ExampleViewController: UIViewController, ZZCarouselDelegate {
         carousel.setCarouselData(carouselData: data)
         carousel.tag = 1001
         
+        carousel1.registerCarouselCell(cellClass: ExampleCell.classForCoder())
         carousel1.delegate = self
         carousel1.setAutoScrollTimeInterval(timeInterval: 2)
         carousel1.setCarouselData(carouselData: data)
         
-        carousel1.registerCarouselCell(cellClass: ExampleCell.classForCoder())
         carousel1.setPageControlAlignment(alignment: ZZCarouselPageAlignment.right)
         carousel1.tag = 1002
         

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/ExampleViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/Demo/ExampleViewController.swift
@@ -98,6 +98,14 @@ class ExampleViewController: UIViewController, ZZCarouselDelegate {
         }
         
     }
+    
+    func totalItemPagger(total: Int) {
+        
+    }
+    
+    func updatePaggerPosition(index: Int) {
+        
+    }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/ViewController.swift
@@ -8,10 +8,17 @@
 
 import UIKit
 
-class ViewController: UIViewController,UITableViewDataSource,UITableViewDelegate,ZZCarouselDelegate{
+class ViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, ZZCarouselDelegate{
     
-    var tableView : UITableView!
-    var carousel : ZZCarouselView!
+    private let tableView : UITableView = {
+        let table = UITableView(frame: .zero, style: .grouped)
+        return table
+    }()
+    
+    private lazy var carousel : ZZCarouselView = {
+        let carousel = ZZCarouselView(width: self.view.frame.size.width, direction: .left)
+        return carousel
+    }()
     
     
     override func viewDidLoad() {
@@ -20,8 +27,9 @@ class ViewController: UIViewController,UITableViewDataSource,UITableViewDelegate
         self.title = "ZZCarouselSwift"
         
         self.view.backgroundColor = UIColor.white
+        setupView()
+        setupConstraits()
         
-        tableView = UITableView.init(frame: self.view.bounds, style: UITableView.Style.grouped)
         tableView.dataSource = self
         tableView.delegate = self
         self.view.addSubview(tableView)
@@ -41,10 +49,25 @@ class ViewController: UIViewController,UITableViewDataSource,UITableViewDelegate
         carousel.endAutoScroll()
     }
     
+    private func setupView() {
+        self.view.addSubview(tableView)
+    }
+    
+    private func setupConstraits() {
+        let views: [String: Any] = ["tableView": tableView]
+        var constraints: [NSLayoutConstraint] = []
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        let v_tableView = "V:|-[tableView]-|"
+        let h_tableView = "H:|-0-[tableView]-0-|"
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: v_tableView, options: .alignAllLeading, metrics: nil, views: views)
+        constraints += NSLayoutConstraint.constraints(withVisualFormat: h_tableView, options: .alignAllTop, metrics: nil, views: views)
+        
+        NSLayoutConstraint.activate(constraints)
+    }
+    
     func instanceCarousel() -> Void {
         let data = ["http://desk.fd.zol-img.com.cn/t_s960x600c5/g5/M00/02/02/ChMkJ1bKxc6IWCE_AAv1GUaUIDYAALHbgFXFK8AC_Ux808.jpg", "http://desk.fd.zol-img.com.cn/t_s960x600c5/g5/M00/02/01/ChMkJlbKxOCIZep0AAU2iZgswEUAALHNgIwWqUABTah055.jpg", "http://desk.fd.zol-img.com.cn/t_s960x600c5/g5/M00/02/01/ChMkJ1bKxOCISXDzAAifUTXHGcMAALHNgI1kUYACJ9p541.jpg","http://desk.fd.zol-img.com.cn/t_s960x600c5/g5/M00/02/01/ChMkJlbKxOCIHZvIAAU6HMJ3XvcAALHNgJBs5oABTo0258.jpg","http://desk.fd.zol-img.com.cn/t_s960x600c5/g5/M00/02/01/ChMkJlbKxOCIDZULAAMuVR0j3-MAALHNgJ_ws4AAy5t818.jpg"]
         
-        carousel = ZZCarouselView.init(frame: CGRect(x: 0, y: 64, width: self.view.frame.size.width, height:150), direction: ZZCarouselScrollDirection.left)
         carousel.registerCarouselCell(cellClass: Example1Cell.self)
         
         carousel.setCurrentPageColor(color: UIColor.orange)
@@ -113,10 +136,10 @@ class ViewController: UIViewController,UITableViewDataSource,UITableViewDelegate
             if indexPath.row == 0 {
                 let ex = ExampleViewController()
                 self.navigationController?.pushViewController(ex, animated: true)
-            }else if indexPath.row == 1 {
+            } else if indexPath.row == 1 {
                 let ex1 = Example1ViewController()
                 self.navigationController?.pushViewController(ex1, animated: true)
-            }else if indexPath.row == 2 {
+            } else if indexPath.row == 2 {
                 let ex1 = Example3ViewController()
                 self.navigationController?.pushViewController(ex1, animated: true)
             }
@@ -124,7 +147,7 @@ class ViewController: UIViewController,UITableViewDataSource,UITableViewDelegate
             if indexPath.row == 0 {
                 let ex1 = Example2ViewController()
                 self.navigationController?.pushViewController(ex1, animated: true)
-            }else if indexPath.row == 1 {
+            } else if indexPath.row == 1 {
                 let ex1 = Example4ViewController()
                 self.navigationController?.pushViewController(ex1, animated: true)
             }
@@ -141,7 +164,12 @@ class ViewController: UIViewController,UITableViewDataSource,UITableViewDelegate
     
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         
-        return section == 0 ? carousel : nil
+        if section == 0 {
+            carousel.sizeToFit()
+            return carousel
+        } else {
+            return nil
+        }
     }
     
     override func didReceiveMemoryWarning() {

--- a/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/ViewController.swift
+++ b/ZZCarouselSwiftDemo/ZZCarouselSwiftDemo/ViewController.swift
@@ -89,6 +89,14 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         print(index)
     }
     
+    func totalItemPagger(total: Int) {
+        print("totalItemPagger(total:) \(total)")
+    }
+    
+    func updatePaggerPosition(index: Int) {
+        print("updatePaggerPosition(index:) \(index)")
+    }
+    
     func numberOfSections(in tableView: UITableView) -> Int {
         return 2
     }


### PR DESCRIPTION
- fix implementation if user using constraint

-  remove public init(frame:direction:) and change to init(width:direction:) instead

- fix variable declaration, dont use mandatory on optional value to prevent any crash on runtime

- fix first time set pageControl position

- fix crash if _carouselData is null


@Glianze 

![it time to](https://github.com/Glianze/ZZCarouselSwift/assets/29350026/707fa55d-9346-4767-9b1f-3ef61212b1f0)
